### PR TITLE
Remove the 300 character limit from the event description attribute.

### DIFF
--- a/back/src/modules/events/dto/create-event.dto.ts
+++ b/back/src/modules/events/dto/create-event.dto.ts
@@ -37,7 +37,6 @@ export class CreateEventDto {
   @IsString()
   @IsNotEmpty()
   @MinLength(80)
-  @MaxLength(300)
   description: string;
 
   @ApiProperty({


### PR DESCRIPTION
Close #164 